### PR TITLE
[sailfishos][gecko] Fix gfxPlatform::AsyncPanZoomEnabled for embedlite. JB#50863

### DIFF
--- a/gfx/thebes/gfxPlatform.cpp
+++ b/gfx/thebes/gfxPlatform.cpp
@@ -3280,7 +3280,7 @@ bool gfxPlatform::UseDesktopZoomingScrollbars() {
 
 /*static*/
 bool gfxPlatform::AsyncPanZoomEnabled() {
-#if !defined(MOZ_WIDGET_ANDROID) && !defined(MOZ_WIDGET_UIKIT)
+#if !defined(MOZ_WIDGET_ANDROID) && !defined(MOZ_WIDGET_UIKIT) && !defined(MOZ_WIDGET_QT)
   // For XUL applications (everything but Firefox on Android)
   // we only want to use APZ when E10S is enabled. If
   // we ever get input events off the main thread we can consider relaxing


### PR DESCRIPTION
sailfishos-esr52 sha1: 017d7e40194c059a2bc8b24ff3aef25f96faf6a3
sailfishos-esr60 sha1: 409d3a8e50829f9f4c35a4707fae53a45515ce5b

Patch 0040 from esr78.